### PR TITLE
[kudox-game] Fix typo usage Kudox Game.

### DIFF
--- a/kudox-game/README.jp.md
+++ b/kudox-game/README.jp.md
@@ -54,7 +54,7 @@ Pro Micro と PC をUSBケーブルで接続し、下記コマンド を実行�
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox-game/rev1:default:avrdude
+$ make kudox_game/rev1:default:avrdude
 ```
 
 文字入力可能なことを確認します.

--- a/kudox-game/README.md
+++ b/kudox-game/README.md
@@ -51,7 +51,7 @@ Follow the QMK installation instructions [here](https://docs.qmk.fm/#/newbs_gett
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox-game/rev1:default:avrdude
+$ make kudox_game/rev1:default:avrdude
 ```
 
 


### PR DESCRIPTION
# 概要

QMK Firmware を利用した Pro Micro 書き込みコマンドに誤りがあったため修正しました.
