### PR TITLE
[README] qmk firmware put via- contorol external repository

### DIFF
--- a/kudox-game/rev2/README.ja.md
+++ b/kudox-game/rev2/README.ja.md
@@ -100,7 +100,8 @@ ProMicro と PC をUSBケーブルで接続し、下記コマンド を実行し
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox_game/rev2:default:flash
+$ qmk compile -kb kudox_game/rev2 -km default
+$ qmk flash -kb kudox_game/rev2 -km default
 ```
 
 文字入力可能なことを確認します.  
@@ -119,22 +120,36 @@ $ make kudox_game/rev2:default:flash
 
 #### 1. VIA 対応ファームの書き込み
 
+kudox_game/rev2/rule.mk を作成し `VIA_ENABLE = yes` を記述します.
+
+```sh
+$ vi qmk_firmware/keyboards/kumaokobo/kudox_game/rev2/rules.mk
+~
+VIA_ENABLE = yes
+~
+```
+
 VIA に対応したファームウェアを書き込みます.
 
 ```sh
+$ git clone https://github.com/qmk/qmk_userspace.git
+$ qmk config user.overlay_dir="$(realpath qmk_userspace)"
 $ cd path/to/qmk_firmware
-$ make kudox_game/rev2:via:flash
+$ qmk userspace-add -kb kudox_game/rev2 -km via
+$ qmk compile -kb kudox_game/rev2 -km via
+$ qmk flash -kb kudox_game/rev2 -km via
 ```
 
 #### 2. VIA のインストール
 
-下記からVIAをダウンロードしてインストールします.
-- [https://www.github.com/the-via/releases/releases/latest](https://www.github.com/the-via/releases/releases/latest)
+ブラウザで VIA を開きます.
+- [https://usevia.app/](https://usevia.app/)
 
 
 #### 3. キーボード設定ファイルの読み込み
 
-キーボードを PC 接続した状態で, VIA の `File` -> `Import Keymap` から 下記のjsonを読み込みます.
+VIA の `DESIGN` -> `Load Draft Definition` から 下記のjsonを読み込みます.  
+キーボードを PC に接続し, `CONFIGURE` -> `Authorize device` を行います.
 - [kudox_game_rev2.json](https://github.com/kumaokobo/kudox-keyboard/blob/master/kudox-game/rev2/kudox_game_rev2.json)
 
 

--- a/kudox-game/rev2/README.md
+++ b/kudox-game/rev2/README.md
@@ -130,11 +130,13 @@ $ qmk compile -kb kudox_game/rev2 -km via
 $ qmk flash -kb kudox_game/rev2 -km via
 ```
 
-Goto VIA by your browser.
+Go to VIA by your browser.
 - [https://usevia.app/](https://usevia.app/)
 
-Plug the keyboard in your PC, select `DESIGN` -> `Load Draft Definition` on VIA and load the json below:
+Select `DESIGN` -> `Load Draft Definition` on VIA and load the json below:
 - [kudox_game_rev2.json](https://github.com/kumaokobo/kudox-keyboard/blob/master/kudox-game/rev2/kudox_game_rev2.json)
+
+Plug the keyboard in your PC, and `CONFIGURE` -> `Authorize device`.
 
 Change keymap by VIA.
 

--- a/kudox-game/rev2/README.md
+++ b/kudox-game/rev2/README.md
@@ -92,7 +92,8 @@ Follow the QMK installation instructions [here](https://docs.qmk.fm/#/newbs_gett
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox_game/rev2:default:flash
+$ qmk compile -kb kudox_game/rev2 -km default
+$ qmk flash -kb kudox_game/rev2 -km default
 ```
 
 Confirm to be able to input chars.  
@@ -110,15 +111,29 @@ You can see keycodes at [keycodes](https://github.com/qmk/qmk_firmware/blob/mast
 
 Burn the firmware compatible with [VIA](https://caniusevia.com/).
 
+Write kudox_game/rev2/rule.mk `VIA_ENABLE = yes`
 ```sh
-$ cd path/to/qmk_firmware
-$ make kudox_game/rev2:via:flash
+$ vi qmk_firmware/keyboards/kumaokobo/kudox_game/rev2/rules.mk
+~
+VIA_ENABLE = yes
+~
 ```
 
-Get VIA and install it.
-- [https://www.github.com/the-via/releases/releases/latest](https://www.github.com/the-via/releases/releases/latest)
+Compile and flash firmware.
 
-Plug the keyboard in your PC, select `File` -> `Import Keymap` on VIA and load the json below:
+```sh
+$ git clone https://github.com/qmk/qmk_userspace.git
+$ qmk config user.overlay_dir="$(realpath qmk_userspace)"
+$ cd path/to/qmk_firmware
+$ qmk userspace-add -kb kudox_game/rev2 -km via
+$ qmk compile -kb kudox_game/rev2 -km via
+$ qmk flash -kb kudox_game/rev2 -km via
+```
+
+Goto VIA by your browser.
+- [https://usevia.app/](https://usevia.app/)
+
+Plug the keyboard in your PC, select `DESIGN` -> `Load Draft Definition` on VIA and load the json below:
 - [kudox_game_rev2.json](https://github.com/kumaokobo/kudox-keyboard/blob/master/kudox-game/rev2/kudox_game_rev2.json)
 
 Change keymap by VIA.

--- a/kudox/rev3/README.ja.md
+++ b/kudox/rev3/README.ja.md
@@ -106,7 +106,8 @@ Kudox Keyboard は [QMK Firmware](https://github.com/qmk/qmk_firmware) を利用
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 ### 初回書き込み時
@@ -146,7 +147,8 @@ $ make kudox/rev3:default:flash
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 #### 3. 動作確認
@@ -162,8 +164,12 @@ $ make kudox/rev3:default:flash
 [qmk_firmware/keyboards/kudox/rev3/keymaps/jis](https://github.com/qmk/qmk_firmware/blob/master/keyboards/kudox/rev3/keymaps/jis/keymap.c) に JIS-like配列を置いていますが, [Qmk Firmware](https://github.com/qmk/qmk_firmware) の [keycodes](https://github.com/qmk/qmk_firmware/blob/master/docs/keycodes.md) を参考にご自身の使いやすいレイアウトに変更してお使いになられると良いかもしれません.  
 
 ```sh
+$ git clone https://github.com/qmk/qmk_userspace.git
+$ qmk config user.overlay_dir="$(realpath qmk_userspace)"
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:jis:flash
+$ qmk userspace-add -kb kudox/rev3 -km jis
+$ qmk compile -kb kudox/rev3 -km jis
+$ qmk flash -kb kudox/rev3 -km jis
 ```
 
 ### オンラインGUIのファームウェア生成ツール
@@ -187,22 +193,37 @@ $ make kudox/rev3:jis:flash
 
 #### 1. VIA 対応ファームの書き込み
 
+kudox/rev3/rule.mk を作成し `VIA_ENABLE = yes` を記述します.
+
+```sh
+$ vi qmk_firmware/keyboards/kumaokobo/kudox/rev3/rules.mk
+~
+VIA_ENABLE = yes
+~
+```
+
 VIA に対応したファームウェアを書き込みます.
 
 ```sh
+$ git clone https://github.com/qmk/qmk_userspace.git
+$ qmk config user.overlay_dir="$(realpath qmk_userspace)"
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:via:flash
+$ qmk userspace-add -kb kudox/rev3 -km via
+$ qmk compile -kb kudox/rev3 -km via
+$ qmk flash -kb kudox/rev3 -km via
 ```
+
 
 #### 2. VIA のインストール
 
-下記からVIAをダウンロードしてインストールします.
-- [https://www.github.com/the-via/releases/releases/latest](https://www.github.com/the-via/releases/releases/latest)
+ブラウザで VIA を開きます.
+- [https://usevia.app/](https://usevia.app/)
 
 
 #### 3. キーボード設定ファイルの読み込み
 
-キーボードを PC 接続した状態で, VIA の `File` -> `Import Keymap` から 下記のjsonを読み込みます.
+VIA の `DESIGN` -> `Load Draft Definition` から 下記のjsonを読み込みます.  
+キーボードを PC に接続し, `CONFIGURE` -> `Authorize device` を行います.
 - [kudox_rev3.json](https://github.com/kumaokobo/kudox-keyboard/blob/master/kudox/rev3/kudox_rev3.json)
 
 

--- a/kudox/rev3/README.ja.md
+++ b/kudox/rev3/README.ja.md
@@ -129,7 +129,8 @@ $ qmk flash -kb kudox/rev3 -km default
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 #### 2. 右手側

--- a/kudox/rev3/README.md
+++ b/kudox/rev3/README.md
@@ -106,7 +106,8 @@ Follow the QMK installation instructions [here](https://docs.qmk.fm/#/newbs_gett
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 ### First time burning
@@ -130,7 +131,8 @@ Compile and burn the firmware by running [Basic compiling and burning command](#
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 #### 2. Right hand side
@@ -149,7 +151,8 @@ Compile and burn the firmware by running [Basic compiling and burning command](#
 
 ```sh
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:default:flash
+$ qmk compile -kb kudox/rev3 -km default
+$ qmk flash -kb kudox/rev3 -km default
 ```
 
 #### 3. Confirmation
@@ -169,20 +172,36 @@ Plug in the Pro Micro (Master) the USB cable.
 
 Burn the firmware compatible with [VIA](https://caniusevia.com/).
 
+Write kudox/rev3/rule.mk `VIA_ENABLE = yes`
 ```sh
+$ vi qmk_firmware/keyboards/kumaokobo/kudox/rev3/rules.mk
+~
+VIA_ENABLE = yes
+~
+```
+
+Compile and flash firmware.
+
+```sh
+$ git clone https://github.com/qmk/qmk_userspace.git
+$ qmk config user.overlay_dir="$(realpath qmk_userspace)"
 $ cd path/to/qmk_firmware
-$ make kudox/rev3:via:flash
+$ qmk userspace-add -kb kudox/rev3 -km via
+$ qmk compile -kb kudox/rev3 -km via
+$ qmk flash -kb kudox/rev3 -km via
 ```
 
 #### 2. Install VIA
 
-Get VIA and install it.
-- [https://www.github.com/the-via/releases/releases/latest](https://www.github.com/the-via/releases/releases/latest)
+Go to VIA by your browser.
+- [https://usevia.app/](https://usevia.app/)
 
 #### 3. Load keyboard specific json
 
 Plug the keyboard in your PC, select `File` -> `Import Keymap` on VIA and load the json below:
 - [kudox_rev3.json](https://github.com/kumaokobo/kudox-keyboard/blob/master/kudox/rev3/kudox_rev3.json)
+
+Plug the keyboard in your PC, and `CONFIGURE` -> `Authorize device`.
 
 #### 4. Change keymap on VIA
 


### PR DESCRIPTION
# About

QMK Firmware での VIA対応の扱いに変更がありました。
VIAに関連するコードは [qmk_userspace](https://github.com/qmk/qmk_userspace) でコントロールすることになったため、 README の ファームウェアの書き込み方を修正しました。

see:
https://docs.qmk.fm/ChangeLog/20240825
